### PR TITLE
Updated VirusShare hash link and added gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/VirusShare_Hashes

--- a/VirusShare-Search.py
+++ b/VirusShare-Search.py
@@ -10,7 +10,7 @@ from urllib.request import urlopen
 
 def downloader(directory, iteration):
 	# Downloads given URL
-	url = 'https://virusshare.com/hashes/VirusShare_%05d.md5' % iteration
+	url = 'https://virusshare.com/hashfiles/VirusShare_%05d.md5' % iteration
 	exists = os.path.isfile(directory + ("\VirusShare_%05d.md5" % iteration))
 	
 	if not exists:


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/74644600/108204390-a74f9b80-711b-11eb-8693-b29dd267ba53.png)

Hi, I've updated the VirusShare hash link to the latest one: https://virusshare.com/hashfiles and added a .gitignore file to ignore VirusShare_Hashes folder. Please let me know if any issues.