### PR TITLE
fixed string interpretation; updated latest file number; remove sleep

### DIFF
--- a/VirusShare-Search.py
+++ b/VirusShare-Search.py
@@ -11,8 +11,8 @@ from urllib.request import urlopen
 def downloader(directory, iteration):
 	# Downloads given URL
 	url = 'https://virusshare.com/hashfiles/VirusShare_%05d.md5' % iteration
-	exists = os.path.isfile(directory + ("\VirusShare_%05d.md5" % iteration))
-	
+	exists = os.path.isfile(directory + (r"\VirusShare_%05d.md5" % iteration))
+
 	if not exists:
 		print("  Downloading {0} into {1}...".format(url, directory))
 
@@ -21,10 +21,8 @@ def downloader(directory, iteration):
 		file_output = open(file_path,'wb')
 		file_output.write(contents.read())
 		file_output.close()
-	else: 	print("Skipping " + directory + ("\VirusShare_%05d.md5" % iteration))
-
-	time.sleep(1)
-
+	else:
+		print("Skipping " + directory + (r"\VirusShare_%05d.md5" % iteration))
 
 def find_missing(directory, latest):
 	# find all files, parse files for end number, remove any files from 'to_find'
@@ -96,7 +94,7 @@ def main():
 	parser = argparse.ArgumentParser(description='tool to download VirusShare hash files and search them for specified hashes')
 	parser.add_argument('-s','--search', help='hash to search for in local repository (hint: specify any number of hashes)', nargs="+")
 	parser.add_argument('-u','--update', help='updates local hash containing files (--update all/missing/10,11,12/0-20)')
-	parser.add_argument('-l','--latest', help='sets latest VirusShare file released (default: 389)', default='389')
+	parser.add_argument('-l','--latest', help='sets latest VirusShare file released (default: 499)', default='499')
 	parser.add_argument('-d','--directory', help='sets working directory (default: VirusShare_Hashes)', default='VirusShare_Hashes')
 
 	args = parser.parse_args()


### PR DESCRIPTION
Without the 'r' character before the strings I received errors since they were not escape codes.

Updated latest file number so you don't have to manually supply it (at least for a little while).

Removed sleep call to speed it up. Personal preference.

~ BryantF